### PR TITLE
A11y megamenu initial build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ pantheon.upstream.yml
 *.jar
 *.rar
 *.tar
-*.zip
 *.tgz
 !wp-includes/**/*.gz
 


### PR DESCRIPTION
- Adding the zip file for the Aten Accessible Menu plugin in its first iteration. 
- Once the WP Starter theme is pushed to this repository the files can be relocated, but for the time being this is the standard method of sharing WP plugins